### PR TITLE
fix: style conflict with theme savor

### DIFF
--- a/index.js
+++ b/index.js
@@ -915,6 +915,11 @@ function setStyle() {
         flex-shrink: 0
     }
 
+    svg.og-fake-doc-breadcrumb-arrow.protyle-breadcrumb__arrow {
+        border: none;
+        transform: none;
+    }
+
     .og-fake-doc-breadcrumb-arrow:hover {
         color: var(--b3-menu-highlight-color);
         background-color: var(--b3-menu-highlight-background);


### PR DESCRIPTION
本插件和 Savor 存在部分样式冲突

![image](https://github.com/OpaqueGlass/syplugin-fakeDocBreadcrumb/assets/27268127/dbffd1a6-abbf-4edd-8d60-d77b1123975f)

![image](https://github.com/OpaqueGlass/syplugin-fakeDocBreadcrumb/assets/27268127/a983d54d-962d-4c6a-bede-ab763e4ee6aa)


本 PR 增加了规则，修复了相关的冲突

```css
svg.og-fake-doc-breadcrumb-arrow.protyle-breadcrumb__arrow {
    border: none;
    transform: none;
}
```